### PR TITLE
Remove hardcoded identifiers; use cache name for cluster_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ module "redis_elasticache" {
   vpc_id = "vpc-20f74844"
   vpc_cidr_block = "10.0.0.0/16"
 
+  cache_name = "cache"
   engine_version = "2.8.22"
   instance_type = "cache.t2.micro"
   maintenance_window = "sun:05:00-sun:06:00"
@@ -25,6 +26,7 @@ module "redis_elasticache" {
 
 - `vpc_id` - ID of VPC meant to house the cache
 - `vpc_cidr_block` - CIDR block of VPC
+- `cache_name` - Name used as ElastiCache cluster ID
 - `engine_version` - Cache engine version (default: `2.8.22`)
 - `instance_type` - Instance type for cache instance (default: `cache.t2.micro`)
 - `maintenance_window` - 60 minute time window to reserve for maintenance

--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,6 @@
 #
 
 resource "aws_security_group" "redis" {
-  name = "cache-security-group"
   vpc_id = "${var.vpc_id}"
 
   ingress {
@@ -30,7 +29,7 @@ resource "aws_security_group" "redis" {
 #
 
 resource "aws_elasticache_cluster" "redis" {
-  cluster_id = "cache"
+  cluster_id = "${var.cache_name}"
   engine = "redis"
   engine_version = "${var.engine_version}"
   maintenance_window = "${var.maintenance_window}"
@@ -47,7 +46,7 @@ resource "aws_elasticache_cluster" "redis" {
 }
 
 resource "aws_elasticache_subnet_group" "default" {
-  name = "cache-subnet-group"
+  name = "${var.cache_name}-subnet-group"
   description = "Private subnets for the ElastiCache instances"
   subnet_ids = ["${split(",", var.private_subnet_ids)}"]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,7 @@
 variable "vpc_id" { }
 variable "vpc_cidr_block" { }
 
+variable "cache_name" { }
 variable "engine_version" {
   default = "2.8.22"
 }


### PR DESCRIPTION
Attempt to remove any hardcoded names from the module so that multiple instances of resources can exist within the same AWS account.
