### PR TITLE
Remove ingress/egress rules; output security group ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ module "redis_elasticache" {
 
 ## Outputs
 
+- `cache_security_group_id` - Security group ID of the cache cluster
 - `hostname` - Public DNS name of cache node
 - `port` - Port of cache instance
 - `endpoint` - Public DNS name and port separated by a `:`

--- a/main.tf
+++ b/main.tf
@@ -5,20 +5,6 @@
 resource "aws_security_group" "redis" {
   vpc_id = "${var.vpc_id}"
 
-  ingress {
-    from_port   = 6379
-    to_port     = 6379
-    protocol    = "tcp"
-    cidr_blocks = ["${var.vpc_cidr_block}"]
-  }
-
-  egress {
-    from_port   = 6379
-    to_port     = 6379
-    protocol    = "tcp"
-    cidr_blocks = ["${var.vpc_cidr_block}"]
-  }
-
   tags {
     Name = "sgCacheCluster"
   }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,7 @@
+output "cache_security_group_id" {
+  value = "${aws_security_group.redis.id}"
+}
+
 output "hostname" {
   value = "${aws_elasticache_cluster.redis.cache_nodes.0.address}"
 }


### PR DESCRIPTION
Instead of defining ingress/egress rules on the `aws_security_group` resource directly, use the `aws_security_group_rule` resource for greater flexibility. In addition, emit the security group ID via a Terraform output variable.

---

**Testing**

I used a Terraform file like this one to test:

``` hcl
provider "aws" {
  region = "us-east-1"
}

module "vpc" {
  source = "github.com/azavea/terraform-aws-vpc?ref=0.4.0"

  name                       = "Default"
  region                     = "us-east-1"
  key_name                   = "joker"
  cidr_block                 = "10.0.0.0/16"
  external_access_cidr_block = "0.0.0.0/0"
  private_subnet_cidr_blocks = "10.0.1.0/24,10.0.3.0/24"
  public_subnet_cidr_blocks  = "10.0.0.0/24,10.0.2.0/24"
  availability_zones         = "us-east-1c,us-east-1d"
  bastion_ami                = "ami-ff02509a"
  bastion_instance_type      = "t2.nano"
}

module "redis_elasticache" {
  source = "/Users/hcastro/Projects/terraform-aws-redis-elasticache"

  vpc_id = "${module.vpc.id}"
  vpc_cidr_block = "${module.vpc.cidr_block}"

  cache_name = "cache"
  engine_version = "2.8.22"
  instance_type = "cache.t2.micro"
  maintenance_window = "sun:05:00-sun:06:00"

  private_subnet_ids = "${module.vpc.private_subnet_ids}"

  alarm_actions = "arn:aws:sns:us-east-1:715496170458:NotifyMe"
}
```
