### PR TITLE
Use aws_elasticache_replication_group resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,44 +5,62 @@ A Terraform module to create an Amazon Web Services (AWS) Redis ElastiCache clus
 ## Usage
 
 ```hcl
-resource "aws_security_group" "redis" {
-  vpc_id = "${vpc.foo.id}"
-
-  tags {
-    Name = "sgCacheCluster"
-  }
+resource "aws_sns_topic" "global" {
+  ...
 }
 
-module "redis_elasticache" {
+resource "aws_elasticache_subnet_group" "redis" {
+  ...
+}
+
+resource "aws_elasticache_parameter_group" "redis" {
+  ...
+}
+
+module "cache" {
   source = "github.com/azavea/terraform-aws-redis-elasticache"
 
-  vpc_id = "vpc-20f74844"
+  vpc_id                     = "vpc-20f74844"
+  cache_identifier           = "cache"
+  automatic_failover_enabled = "false"
+  desired_clusters           = "1"
+  instance_type              = "cache.t2.micro"
+  engine_version             = "3.2.4"
+  parameter_group            = "${aws_elasticache_parameter_group.redis.name}"
+  subnet_group               = "${aws_elasticache_subnet_group.redis.name}"
+  maintenance_window         = "sun:02:30-sun:03:30"
+  notification_topic_arn     = "${aws_sns_topic.global.arn}"
 
-  cache_name = "cache"
-  engine_version = "2.8.22"
-  instance_type = "cache.t2.micro"
-  maintenance_window = "sun:05:00-sun:06:00"
+  alarm_cpu_threshold    = "75"
+  alarm_memory_threshold = "10000000"
+  alarm_actions          = ["${aws_sns_topic.global.arn}"]
 
-  private_subnet_ids = ["subnet-4a887f3c","subnet-76dae35d"]
-  security_group_ids = ["${aws_security_group.redis.id}"]
-
-  alarm_action = "arn:aws:sns..."
+  project     = "Unknown"
+  environment = "Unknown"
 }
 ```
 
 ## Variables
 
 - `vpc_id` - ID of VPC meant to house the cache
-- `cache_name` - Name used as ElastiCache cluster ID
-- `engine_version` - Cache engine version (default: `2.8.22`)
+- `project` - Name of the project making use of the cluster (default: `Unknown`)
+- `environment` - Name of environment the cluster is targeted for (default: `Unknown`)
+- `cache_identifier` - Name used as ElastiCache cluster ID
+- `automatic_failover_enabled` - Flag to determine if automatic failover should be enabled
+- `desired_clusters` - Number of cache clusters in replication group
 - `instance_type` - Instance type for cache instance (default: `cache.t2.micro`)
-- `maintenance_window` - 60 minute time window to reserve for maintenance
-  (default: `sun:05:00-sun:06:00`)
-- `private_subnet_ids` - Comma delimited list of private subnet IDs
-- `alarm_action` - ARN to be notified via CloudWatch
+- `engine_version` - Cache engine version (default: `3.2.4`)
+- `parameter_group` - Cache parameter group name (default: `redis3.2`)
+- `subnet_group` - Cache subnet group name
+- `maintenance_window` - Time window to reserve for maintenance
+- `notification_topic_arn` - ARN to notify when cache events occur
+- `alarm_cpu_threshold` - CPU alarm threshold as a percentage (default: `75`)
+- `alarm_memory_threshold` - Free memory alarm threshold in bytes (default: `10000000`)
+- `alarm_actions` - ARN to be notified via CloudWatch when alarm thresholds are triggered
 
 ## Outputs
 
-- `hostname` - Public DNS name of cache node
-- `port` - Port of cache instance
-- `endpoint` - Public DNS name and port separated by a `:`
+- `id` - The replication group ID
+- `cache_security_group_id` - Security group ID of the cache cluster
+- `port` - Port of replication group leader
+- `endpoint` - Public DNS name of replication group leader

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,11 +1,15 @@
-output "hostname" {
-  value = "${aws_elasticache_cluster.redis.cache_nodes.0.address}"
+output "id" {
+  value = "${aws_elasticache_replication_group.redis.id}"
+}
+
+output "cache_security_group_id" {
+  value = "${aws_security_group.redis.id}"
 }
 
 output "port" {
-  value = "${aws_elasticache_cluster.redis.cache_nodes.0.port}"
+  value = "6379"
 }
 
 output "endpoint" {
-  value = "${join(":", aws_elasticache_cluster.redis.cache_nodes.0.address, aws_elasticache_cluster.redis.cache_nodes.0.port)}"
+  value = "${aws_elasticache_replication_group.redis.primary_endpoint_address}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,29 +1,50 @@
-variable "vpc_id" {
+variable "project" {
+  default = "Unknown"
 }
 
-variable "cache_name" {
+variable "environment" {
+  default = "Unknown"
 }
 
-variable "engine_version" {
-  default = "2.8.22"
+variable "vpc_id" {}
+
+variable "cache_identifier" {}
+
+variable "parameter_group" {
+  default = "redis3.2"
+}
+
+variable "subnet_group" {}
+
+variable "maintenance_window" {}
+
+variable "desired_clusters" {
+  default = "1"
 }
 
 variable "instance_type" {
   default = "cache.t2.micro"
 }
 
-variable "maintenance_window" {
-  # SUN 01:00AM-02:00AM ET
-  default = "sun:05:00-sun:06:00"
+variable "engine_version" {
+  default = "3.2.4"
 }
 
-variable "private_subnet_ids" {
-  type = "list"
+variable "automatic_failover_enabled" {
+  default = false
 }
 
-variable "alarm_action" {
+variable "notification_topic_arn" {}
+
+variable "alarm_cpu_threshold" {
+  default = "75"
 }
 
-variable "security_group_ids" {
+variable "alarm_memory_threshold" {
+  # 10MB
+  default = "10000000"
+}
+
+variable "alarm_actions" {
   type = "list"
 }


### PR DESCRIPTION
Instead of using the more primitive `aws_elasticache_cluster` resource, create a Redis ElastiCache replication group with the `aws_elasticache_replication_group` resource. This comes with a hot-standby and support for automatic failover.

Also, follow the pattern set forth by the RDS module:

- Remove all resources other than cache cluster and CloudWatch alarms
- Add empty security group resource and emit its ID as an output

---

**Testing**

Use https://github.com/azavea/raster-foundry-deployment/pull/16/ to test.