### PR TITLE
project naming + security group ingress

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,15 +1,28 @@
 #
 # Security group resources
 #
+
 resource "aws_security_group" "redis" {
-  vpc_id = "${var.vpc_id}"
+  vpc_id  = "${var.vpc_id}"
+  name    = "${var.project}-${var.environment}"
 
   tags {
-    Name        = "sgCacheCluster"
+    Name        = "${var.project}-${var.environment}-security-group"
     Project     = "${var.project}"
     Environment = "${var.environment}"
   }
 }
+
+resource "aws_security_group_rule" "allow_all" {
+  type            = "ingress"
+  from_port       = 6379
+  to_port         = 6379
+  protocol        = "tcp"
+  cidr_blocks     = ["0.0.0.0/0"]
+
+  security_group_id = "${aws_security_group.redis.id}"
+}
+
 
 #
 # ElastiCache resources
@@ -29,7 +42,7 @@ resource "aws_elasticache_replication_group" "redis" {
   port                          = "6379"
 
   tags {
-    Name        = "CacheReplicationGroup"
+    Name        = "${var.project}-${var.environment}-replication-group"
     Project     = "${var.project}"
     Environment = "${var.environment}"
   }


### PR DESCRIPTION
Not sure if you care to merge this or not but I made a couple modifications that were helpful for me.

I added the naming change because I often have to manage multiple projects and ensuring there isn't naming conflicts is important to me. Also, this gives you granularity at the security group level for multiple projects.

I also added a default group rule so that you don't have to go to console and modify it manually. This might not be ideal for non VPC related deployments but AFAICT this module is meant for VPC deployments so VPC rules should keep it safe, especially if you are deploying to a private subnet as I am.

Let me know if you have any questions, great module - it was very help for me. Thanks!